### PR TITLE
Fix possible panics - harden MQTT topic and payload handling

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -67,12 +67,12 @@ func serializeEvent(source string, data interface{}) []byte {
 }
 
 func (d *EventDispatcher) broadcastEvent(source string, data interface{}) {
-	if len(source) > 6 && source[0:6] == "local/" {
+	if len(source) >= 6 && source[0:6] == "local/" {
 		// local events don't broadcast anywhere
 		topic := source[6:]
 		value := fmt.Sprintf("%v", data)
 		log.Infof("LOCAL: %s -> %s", topic, value)
-	} else if source[0:5] == "mqtt/" {
+	} else if len(source) >= 5 && source[0:5] == "mqtt/" {
 		if mqttClient != nil {
 			topic := source[5:]
 			value := fmt.Sprintf("%v", data)
@@ -120,8 +120,8 @@ func  mqttMessageHandler(client mqtt.Client, msg mqtt.Message) {
 		log.Errorf("mqtt received unexpected topic '%s'", msg.Topic())
 	} else if len(ts) == 5 && ts[1] == "zone" {
 		// zone-based
-		if ps[len(ps)-2:len(ps)-1] == "." {
-			ps = ps[0:len(ps)-2]
+		if strings.HasSuffix(ps, ".0") {
+			ps = ps[:len(ps)-2]
 		}
 		_ = putConfig(ts[2], ts[3], ps)
 	} else if len(ts) == 4 && ts[1] == "vacation" {
@@ -149,7 +149,13 @@ func ConnectMqtt(url string, password string) {
 	co.SetPassword(password)
 	co.SetClientID(instanceName + "_mqtt_client")
 	co.SetOnConnectHandler(mqttOnConnect)
-	co.SetConnectionLostHandler(func(cl mqtt.Client, err error) {log.Info("MQTT: Connection lost: ", err.Error())})
+	co.SetConnectionLostHandler(func(cl mqtt.Client, err error) {
+		if err != nil {
+			log.Info("MQTT: Connection lost: ", err.Error())
+		} else {
+			log.Info("MQTT: Connection lost")
+		}
+	})
 	co.SetReconnectingHandler(func(cl mqtt.Client, _ *mqtt.ClientOptions) {log.Info("MQTT: Trying to reconnect")})
 	co.SetConnectRetry(true)
 	co.SetConnectRetryInterval(time.Minute)
@@ -301,7 +307,7 @@ func mqttOnConnect(cl mqtt.Client) {
 // post discovery message if needed
 func mqttDiscoverZone(zi int, zn string, tu uint8) {
 
-	if mqttZoneFlags[zi] || !mqttClient.IsConnected() {
+	if mqttClient == nil || mqttZoneFlags[zi] || !mqttClient.IsConnected() {
 		return
 	}
 


### PR DESCRIPTION
I ran into a daemon panic when manually testing the override duration MQTT publishing in MQTT explorer.
It occurred to me to check if there were other possible such cases. Codex found some edge cases. I don't know if they are truly legit. There are no existing automated test cases for MQTT that I see. Or really, any tests at all.

So, this will need some thought in order to figure out whether some of these additional checks may cause regressions or not. It looks OK eyeballing it, but everything from LLM does, so another human review is desired.

